### PR TITLE
Disable core dumps

### DIFF
--- a/coredump/60-solus-coredump.conf
+++ b/coredump/60-solus-coredump.conf
@@ -1,1 +1,1 @@
-kernel.core_pattern=
+kernel.core_pattern=|/bin/false


### PR DESCRIPTION
With the update to the latest version of systemd, dmesg is getting spammed with a lot of errors related to kernel.core_pattern not being set to a valid handler / path

```
[   12.422112] Unsafe core_pattern used with fs.suid_dumpable=2.
               Pipe handler or fully qualified core dump path required.
               Set kernel.core_pattern before fs.suid_dumpable.
```
We already have their generation disabled here:
https://github.com/getsolus/solus-hardware-config/blob/7da91b6f2915597d6a4cb3eab7082fc732d7c057/coredump/00-coredumpd-solus.conf#L2

With this change I no longer get spammed with the error.

Cheers.
